### PR TITLE
Change weirdly phrased str for delayed recordings

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -217,11 +217,11 @@ const EasyScreenCast_Indicator = new Lang.Class({
 
         var secDelay = Pref.getOption('i', Pref.TIME_DELAY_SETTING_KEY);
         if (secDelay > 1) {
-            this.smDelayRec.label.text = secDelay + _(' seconds of delay in registration');
+            this.smDelayRec.label.text = secDelay + _(' sec. delay before recording');
         } else if (secDelay === 1) {
-            this.smDelayRec.label.text = _('1 second of delay in registration');
+            this.smDelayRec.label.text = _('1 sec. delay before recording');
         } else {
-            this.smDelayRec.label.text = _('No delay in the registration');
+            this.smDelayRec.label.text = _('Start recording immediately');
         }
 
         this.menu.addMenuItem(this.smDelayRec);


### PR DESCRIPTION
Abbreviating “seconds” as it’s not common to write out the full word. Would be nice to conserve some width in this UI. Leaving logic for plural forms in place even though it’s not needed for English, as other languages may still need it.

I agree with the project license and for this pull request to be distributed under the terms of the project’s license.