### PR TITLE
Fix clean opts

### DIFF
--- a/utilwebcam.js
+++ b/utilwebcam.js
@@ -129,7 +129,8 @@ const HelperWebcam = new Lang.Class({
         for (var i = 0; i < tmpCaps.get_size(); i++) {
             //cleaned cap
             var tmpStr = tmpCaps.get_structure(i).to_string()
-                .replace(/\(.*?\)|;/gi, '');
+                .replace(/;/gi, '')
+                .replace(/\((.*?)\)/gi, '\($1\)');
 
             //fine cleaning of option CAPS remain
             cleanCaps[i] = this.cleanCapsOPT(tmpStr);

--- a/utilwebcam.js
+++ b/utilwebcam.js
@@ -148,10 +148,13 @@ const HelperWebcam = new Lang.Class({
             //clean
             var firstOPT = strCaps.indexOf('{ ');
             var lastOPT = strCaps.indexOf(' }');
+            var nextMedia = strCaps.indexOf(',', firstOPT)
+            if (strCaps.indexOf(',', firstOPT) + 1 > lastOPT + 2)
+		nextMedia = lastOPT;
 
             var strInitial = strCaps.substr(0, firstOPT);
             var strMedia = strCaps.substring(firstOPT + 2,
-                strCaps.indexOf(',', firstOPT));
+                nextMedia);
             var strPost = strCaps.substr(lastOPT + 2);
 
             var tmpStr = strInitial + strMedia + strPost;

--- a/utilwebcam.js
+++ b/utilwebcam.js
@@ -157,7 +157,7 @@ const HelperWebcam = new Lang.Class({
             var tmpStr = strInitial + strMedia + strPost;
             Lib.TalkativeLog('-@-cleaned caps:' + tmpStr);
             //recall
-            this.cleanCapsOPT(tmpStr);
+            return this.cleanCapsOPT(tmpStr);
         } else {
             return strCaps;
         }


### PR DESCRIPTION
the first patch could be in a different PR per it is a generic fix. That is cleanCapsOPT does not return anything if a brace matches.


The next two are to cope with fields that holds non trivial types (here colorimetry). The colorimetry holds its value inside brace but this one is not a range. The second patch is to handle the "allocation size overflow" error that ensue (the matching comma is beyond the closing brace).

The third one restore the parenthesis around type specifier but escape them. I do not know the rationale for them to be stripped. Without this type specifier the capture  command holds colorimetry=2:4:7:1 which ends up with a not catched "flow control" gstreamer error when capture is processing.The output file is created but empty. I cannot tell why the parens where quoted at first so hard to tell if I can keep this feature ok. This one is the most invasive patch.
Another way than keep the type specifier would be to parse each field and map their name to a type to restore it in the capture command. But this looks heavyweight at first sight.