### PR TITLE
Fix windowselection

### DIFF
--- a/selection.js
+++ b/selection.js
@@ -264,8 +264,9 @@ const SelectionWindow = new Lang.Class({
     },
 
     _highlightWindow: function(win) {
-        Lib.TalkativeLog('-£-window highlight on, pos/meas: ' + getWindowRectangle(win));
-        this._capture.drawSelection(getWindowRectangle(win), false);
+        let rect = getWindowRectangle(win);
+        Lib.TalkativeLog('-£-window highlight on, pos/meas: x:' + rect.x + ' y:' + rect.y +' w:' + rect.w + ' h:' + rect.h);
+        this._capture.drawSelection(rect, false);
     },
 
     _clearHighlight: function() {

--- a/selection.js
+++ b/selection.js
@@ -249,6 +249,8 @@ const SelectionWindow = new Lang.Class({
 
                 Lib.TalkativeLog('-£-windows pre wx: ' + wx + ' wy: ' + wy + ' height: ' + h + '  width: ' + w);
 
+                if (wx < 0) wx = 0;
+                if (wy < 0) wy = 0;
                 if (wx + w > tmpM.width) {
                     w -= Math.abs((wx + w) - tmpM.width);
                 }

--- a/selection.js
+++ b/selection.js
@@ -398,14 +398,14 @@ const getRectangle = function(x1, y1, x2, y2) {
 
 
 const getWindowRectangle = function(win) {
-    let tmpSize = win.get_size();
-    let tmpPosition = win.get_position();
+    let [tw, th] = win.get_size();
+    let [tx,ty] = win.get_position();
 
     return {
-        x: tmpPosition.x,
-        y: tmpPosition.y,
-        w: tmpSize.width,
-        h: tmpSize.height
+        x: tx,
+        y: ty,
+        w: tw,
+        h: th
     };
 };
 

--- a/utilwebcam.js
+++ b/utilwebcam.js
@@ -148,10 +148,13 @@ const HelperWebcam = new Lang.Class({
             //clean
             var firstOPT = strCaps.indexOf('{ ');
             var lastOPT = strCaps.indexOf(' }');
+            var nextMedia = strCaps.indexOf(',', firstOPT)
+            if (strCaps.indexOf(',', firstOPT) + 1 > lastOPT + 2)
+		nextMedia = lastOPT;
 
             var strInitial = strCaps.substr(0, firstOPT);
             var strMedia = strCaps.substring(firstOPT + 2,
-                strCaps.indexOf(',', firstOPT));
+                nextMedia);
             var strPost = strCaps.substr(lastOPT + 2);
 
             var tmpStr = strInitial + strMedia + strPost;

--- a/utilwebcam.js
+++ b/utilwebcam.js
@@ -129,7 +129,7 @@ const HelperWebcam = new Lang.Class({
         for (var i = 0; i < tmpCaps.get_size(); i++) {
             //cleaned cap
             var tmpStr = tmpCaps.get_structure(i).to_string()
-                .replace(/\(.*?\)|;/gi, '');
+                .replace(/;/gi, '');
 
             //fine cleaning of option CAPS remain
             cleanCaps[i] = this.cleanCapsOPT(tmpStr);

--- a/utilwebcam.js
+++ b/utilwebcam.js
@@ -157,7 +157,7 @@ const HelperWebcam = new Lang.Class({
             var tmpStr = strInitial + strMedia + strPost;
             Lib.TalkativeLog('-@-cleaned caps:' + tmpStr);
             //recall
-            this.cleanCapsOPT(tmpStr);
+            return this.cleanCapsOPT(tmpStr);
         } else {
             return strCaps;
         }


### PR DESCRIPTION
the first patch is a generic fix. That is cleanCapsOPT does not return anything if a brace matches.

alas the fourth, fifth and sixth  ones which revolves around window selection record fxes.
Fourth : extends the debugging output to show  that getWindowRectangle returns undefined values in its current state.
Fifth: fixes getWindowRectange to returns the values : x, y, width and height.
Sixth: to cast wx and wy the x and y top left position of the window to positive values as otherwise the recording workflow complains about invalid params. 

The second and third ones are more specific to a use case. That is my caps includes colorimetry.
The colorimetry holds its value inside brace but this one is not a range.

The second patch  handles the "allocation size overflow" error that ensue from brace without comma inside : that is the  indexof call will find a comma but  beyond the closing brace.

The third one restore the parenthesis with the  type specifier.  I do not know the rationale for them to be stripped. 
Without this type specifier the capture command holds colorimetry=2:4:7:1 ends up with a not catched "flow control"  error from gstreamer  when capture  is processing.The output file is created but empty.This one is the most invasive patch.

Another way to handle colorimetry  would be to parse each field and map their name to a type to restore it in the capture command. But this looks heavyweight..